### PR TITLE
Split exceptions classes

### DIFF
--- a/src/ZBApiException.php
+++ b/src/ZBApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZeroBounce\SDK;
+
+class ZBApiException extends ZBException
+{
+}

--- a/src/ZBException.php
+++ b/src/ZBException.php
@@ -7,15 +7,3 @@ use Exception;
 class ZBException extends Exception
 {
 }
-
-class ZBMissingApiKeyException extends ZBException
-{
-}
-
-class ZBMissingParameterException extends ZBException
-{
-}
-
-class ZBApiException extends ZBException
-{
-}

--- a/src/ZBMissingApiKeyException.php
+++ b/src/ZBMissingApiKeyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZeroBounce\SDK;
+
+class ZBMissingApiKeyException extends ZBException
+{
+}

--- a/src/ZBMissingParameterException.php
+++ b/src/ZBMissingParameterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ZeroBounce\SDK;
+
+class ZBMissingParameterException extends ZBException
+{
+}


### PR DESCRIPTION
HI @vlungusst @antonio-bigan 

When using this lib without an api key I got 
<img width="906" alt="image" src="https://github.com/zerobounce/zero-bounce-php-sdk-setup/assets/9052536/13744441-5f3f-47cd-8160-54a850ea38a1">

Seems like having multiple classes in the same file is not helping the autoload/discovery.
It would be better to have one class per file.