### PR TITLE
Add null to all the non initialized properties

### DIFF
--- a/src/ZBActivityResponse.php
+++ b/src/ZBActivityResponse.php
@@ -5,12 +5,12 @@ namespace ZeroBounce\SDK;
 class ZBActivityResponse extends ZBResponse
 {
     /**
-     * @var bool
+     * @var bool|null
      */
     public $found;
 
     /**
-     * @var int
+     * @var int|null
      */
     public $activeInDays;
 

--- a/src/ZBApiUsageResponse.php
+++ b/src/ZBApiUsageResponse.php
@@ -5,60 +5,60 @@ namespace ZeroBounce\SDK;
 class ZBApiUsageResponse extends ZBResponse
 {
     /**
-     * @var int
+     * @var int|null
      */
     public $total;
 
     /**
      * Total valid email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusValid;
 
     /**
      * Total invalid email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusInvalid;
 
     /**
      * Total catch-all email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusCatchAll;
 
     /**
      * Total do not mail email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusDoNotMail;
 
     /**
      * Total spamtrap email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusSpamtrap;
 
     /**
      * Total unknown email addresses returned by the API
-     * @var int
+     * @var int|null
      */
     public $statusUnknown;
 
     /** Total number of times the API has a sub status of "toxic"
-     * @var int
+     * @var int|null
      */
     public $subStatusToxic;
 
     /**
      * Total number of times the API has a sub status of "disposable"
-     * @var int
+     * @var int|null
      */
     public $subStatusDisposable;
 
     /**
      * Total number of times the API has a sub status of "role_based"
-     * @var int
+     * @var int|null
      */
     public $subStatusRoleBased;
 
@@ -68,115 +68,115 @@ class ZBApiUsageResponse extends ZBResponse
     public $subStatusPossibleTrap;
 
     /** Total number of times the API has a sub status of "global_suppression"
-     * @var int
+     * @var int|null
      */
     public $subStatusGlobalSuppression;
 
     /**
      * Total number of times the API has a sub status of "timeout_exceeded"
-     * @var int
+     * @var int|null
      */
     public $subStatusTimeoutExceeded;
 
     /**
      * Total number of times the API has a sub status of "mail_server_temporary_error"
-     * @var int
+     * @var int|null
      */
     public $subStatusMailServerTemporaryError;
 
     /**
      * Total number of times the API has a sub status of "mail_server_did_not_respond"
-     * @var int
+     * @var int|null
      */
     public $subStatusMailServerDidNotResponse;
 
     /**
      * Total number of times the API has a sub status of "greylisted"
-     * @var int
+     * @var int|null
      */
     public $subStatusGreyListed;
 
     /**
      * Total number of times the API has a sub status of "antispam_system"
-     * @var int
+     * @var int|null
      */
     public $subStatusAntiSpamSystem;
 
     /**
      * Total number of times the API has a sub status of "does_not_accept_mail"
-     * @var int
+     * @var int|null
      */
     public $subStatusDoesNotAcceptMail;
 
     /**
      * Total number of times the API has a sub status of "exception_occurred"
-     * @var int
+     * @var int|null
      */
     public $subStatusExceptionOccurred;
 
     /**
      * Total number of times the API has a sub status of "failed_syntax_check"
-     * @var int
+     * @var int|null
      */
     public $subStatusFailedSyntaxCheck;
 
     /**
      * Total number of times the API has a sub status of "mailbox_not_found"
-     * @var int
+     * @var int|null
      */
     public $subStatusMailboxNotFound;
 
     /**
      * Total number of times the API has a sub status of "unroutable_ip_address"
-     * @var int
+     * @var int|null
      */
     public $subStatusUnRoutableIpAddress;
 
     /**
      * Total number of times the API has a sub status of "possible_typo"
-     * @var int
+     * @var int|null
      */
     public $subStatusPossibleTypo;
 
     /**
      * Total number of times the API has a sub status of "no_dns_entries"
-     * @var int
+     * @var int|null
      */
     public $subStatusNoDnsEntries;
 
     /**
      * Total role based catch alls the API has a sub status of "role_based_catch_all"
-     * @var int
+     * @var int|null
      */
     public $subStatusRoleBasedCatchAll;
 
     /**
      * Total number of times the API has a sub status of "mailbox_quota_exceeded"
-     * @var int
+     * @var int|null
      */
     public $subStatusMailboxQuotaExceeded;
 
     /**
      * Total forcible disconnects the API has a sub status of "forcible_disconnect"
-     * @var int
+     * @var int|null
      */
     public $subStatusForcibleDisconnect;
 
     /**
      * Total failed SMTP connections the API has a sub status of "failed_smtp_connection"
-     * @var int
+     * @var int|null
      */
     public $subStatusFailedSmtpConnection;
 
     /**
      * Start date of query
-     * @var string
+     * @var string|null
      */
     public $startDate;
 
     /**
      * End date of query
-     * @var string
+     * @var string|null
      */
     public $endDate;
 

--- a/src/ZBBatchValidateResponse.php
+++ b/src/ZBBatchValidateResponse.php
@@ -8,12 +8,12 @@ class ZBBatchValidateResponse extends ZBResponse
      * The batch of email addresses you are validating.
      * @var array
      */
-    public $emailBatch;
+    public $emailBatch = [];
 
     /**
      * @var array
      */
-    public $errors;
+    public $errors = [];
 
     public function __toString()
     {

--- a/src/ZBDeleteFileResponse.php
+++ b/src/ZBDeleteFileResponse.php
@@ -5,22 +5,22 @@ namespace ZeroBounce\SDK;
 class ZBDeleteFileResponse extends ZBResponse
 {
     /**
-     * @var bool
+     * @var bool|null
      */
     public $success;
 
     /**
      * @var array
      */
-    public $message;
+    public $message = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileName;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileId;
 

--- a/src/ZBFileStatusResponse.php
+++ b/src/ZBFileStatusResponse.php
@@ -5,42 +5,42 @@ namespace ZeroBounce\SDK;
 class ZBFileStatusResponse extends ZBResponse
 {
     /**
-     * @var bool
+     * @var bool|null
      */
     public $success;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $message;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileStatus;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileId;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileName;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $uploadDate;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $completePercentage;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $returnUrl;
 

--- a/src/ZBGetCreditsResponse.php
+++ b/src/ZBGetCreditsResponse.php
@@ -5,7 +5,7 @@ namespace ZeroBounce\SDK;
 class ZBGetCreditsResponse extends ZBResponse
 {
     /**
-     * @var string
+     * @var string|null
      */
     public $credits;
 

--- a/src/ZBGetFileResponse.php
+++ b/src/ZBGetFileResponse.php
@@ -5,7 +5,7 @@ namespace ZeroBounce\SDK;
 class ZBGetFileResponse extends ZBResponse
 {
     /**
-     * @var string
+     * @var string|null
      */
     public $localFilePath;
 

--- a/src/ZBGuessFormatResponse.php
+++ b/src/ZBGuessFormatResponse.php
@@ -6,49 +6,51 @@ class ZBGuessFormatResponse extends ZBResponse
 {
     /**
      * The email address beign guessed.
-     * @var string
+     * @var string|null
      */
     public $email;
 
     /**
      * Domain guess is being performed for.
-     * @var string
+     * @var string|null
      */
     public $domain;
 
     /**
      * Most likely email format.
-     * @var string
+     * @var string|null
      */
     public $format;
 
     /**
      * Guess status.
-     * @var ZBValidateStatus
+     * @var string|null
+     * @see ZBValidateStatus
      */
     public $status;
 
     /**
      * Guess substatus.
-     * @var ZBValidateSubStatus
+     * @var string|null
+     * @see ZBValidateSubStatus
      */
     public $subStatus;
 
     /**
      * Confidence in guess.
-     * @var string
+     * @var string|null
      */
     public $confidence;
 
     /**
      * Suggestion for guess.
-     * @var string
+     * @var string|null
      */
     public $didYouMean;
 
     /**
      * Reason for error.
-     * @var string
+     * @var string|null
      */
     public $failureReason;
 
@@ -56,7 +58,7 @@ class ZBGuessFormatResponse extends ZBResponse
      * Other possible guess formats.
      * @var array
      */
-    public $otherDomainFormats;
+    public $otherDomainFormats = [];
 
     public function getValue($classKey, $value)
     {
@@ -68,14 +70,14 @@ class ZBGuessFormatResponse extends ZBResponse
     public function __toString()
     {
         return "ZBValidateResponse{" .
-            "email=" . $this->email . ", " . 
-            "status=" . $this->domain . ", " . 
+            "email=" . $this->email . ", " .
+            "status=" . $this->domain . ", " .
             "format=" . $this->format . ", " .
-            "status=" . $this->status . ", " . 
-            "subStatus=" . $this->subStatus . ", " . 
-            "confidence=" . $this->confidence . ", " . 
-            "didYouMean=" . $this->didYouMean . ", " . 
-            "failureReason=" . $this->failureReason . ", " . 
+            "status=" . $this->status . ", " .
+            "subStatus=" . $this->subStatus . ", " .
+            "confidence=" . $this->confidence . ", " .
+            "didYouMean=" . $this->didYouMean . ", " .
+            "failureReason=" . $this->failureReason . ", " .
             "}";
     }
 }

--- a/src/ZBSendFileResponse.php
+++ b/src/ZBSendFileResponse.php
@@ -5,22 +5,22 @@ namespace ZeroBounce\SDK;
 class ZBSendFileResponse extends ZBResponse
 {
     /**
-     * @var bool
+     * @var bool|null
      */
     public $success;
 
     /**
      * @var array
      */
-    public $message;
+    public $message = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileName;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $fileId;
 

--- a/src/ZBValidateResponse.php
+++ b/src/ZBValidateResponse.php
@@ -6,13 +6,14 @@ class ZBValidateResponse extends ZBResponse
 {
     /**
      * The email address you are validating.
-     * @var string
+     * @var string|null
      */
     public $address;
 
     /**
      * [valid, invalid, catch-all, unknown, spamtrap, abuse, do_not_mail]
-     * @var ZBValidateStatus
+     * @var string|null
+     * @see ZBValidateStatus
      */
     public $status;
 
@@ -22,101 +23,109 @@ class ZBValidateResponse extends ZBResponse
      * role_based, global_suppression, mailbox_not_found, no_dns_entries, failed_syntax_check, possible_typo,
      * unroutable_ip_address, leading_period_removed, does_not_accept_mail, alias_address,
      * role_based_catch_all, disposable, toxic]
-     * @var ZBValidateSubStatus
+     * @var string|null
+     * @see ZBValidateSubStatus
      */
     public $subStatus;
 
     /**
      * The portion of the email address before the "@" symbol.
-     * @var string
+     * @var string|null
      */
     public $account;
 
     /**
      * The portion of the email address after the "@" symbol.
-     * @var string
+     * @var string|null
      */
     public $domain;
 
     /**
      * Suggestive Fix for an email typo
-     * @var string
+     * @var string|null
      */
     public $didYouMean;
 
     /**
      * Age of the email domain in days or [null].
-     * @var string
+     * @var string|null
      */
     public $domainAgeDays;
 
     /**
      * [true/false] If the email comes from a free provider.
-     * @var bool
+     * @var bool|null
      */
     public $freeEmail;
 
     /**
      * [true/false] Does the domain have an MX record.
-     * @var bool
+     * @var bool|null
      */
     public $mxFound;
 
     /**
      * The preferred MX record of the domain
-     * @var string
+     * @var string|null
      */
     public $mxRecord;
 
     /**
      * The SMTP Provider of the email or [null] [BETA].
-     * var string
+     * @var string|null
      */
     public $smtpProvider;
 
     /**
      * The first name of the owner of the email when available or [null].
-     * @var string
+     * @var string|null
      */
     public $firstName;
 
-    /**The last name of the owner of the email when available or [null].
-     * @var string
+    /**
+     * The last name of the owner of the email when available or [null].
+     * @var string|null
      */
     public $lastName;
 
-    /**The gender of the owner of the email when available or [null].
-     * @var string
+    /**
+     * The gender of the owner of the email when available or [null].
+     * @var string|null
      */
     public $gender;
 
-    /**The city of the IP passed in.
-     * @var string
+    /**
+     * The city of the IP passed in.
+     * @var string|null
      */
     public $city;
 
-    /**The region/state of the IP passed in.
-     * @var string
+    /**
+     * The region/state of the IP passed in.
+     * @var string|null
      */
     public $region;
 
-    /**The zipcode of the IP passed in.
-     * @var string
+    /**
+     * The zipcode of the IP passed in.
+     * @var string|null
      */
     public $zipcode;
 
-    /**The country of the IP passed in.
-     * @var string
+    /**
+     * The country of the IP passed in.
+     * @var string|null
      */
     public $country;
 
-    /**The UTC time the email was validated.
-     * @var string
+    /**
+     * The UTC time the email was validated.
+     * @var string|null
      */
     public $processedAt;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $error;
 


### PR DESCRIPTION
Hi @vlungusst @antonio-bigan 

Unlike the phpdoc is saying, almost every properties of every response are nullable

For instance I get a dump of the ZBValidateResponse
<img width="405" alt="image" src="https://github.com/zerobounce/zero-bounce-php-sdk-setup/assets/9052536/d48f1d4f-2326-4e0b-89a1-c6ffea2f6124">

You can also reproduce by doing
```
(new ZBValidateResponse())->status
```

The phpdoc would warn the user about the possible null values.

For array properties, I initialized with `[]` because the code are sometimes doing foreach on them, and doing a foreach on null trigger a warning.