### PR TITLE
Improve debugging for invalid response

### DIFF
--- a/src/ZBResponse.php
+++ b/src/ZBResponse.php
@@ -6,11 +6,17 @@ class ZBResponse
 {
     /**
      * @param string|array $json
+     * @throws ZBException
      */
     public function Deserialize($json)
     {
-        if (is_string($json))
-            $json = json_decode($json);
+        if (is_string($json)) {
+            $decodedJson = json_decode($json, true);
+            if (!\is_array($decodedJson)) {
+                throw new ZBException(sprintf('Invalid response "%s".', $json));
+            }
+            $json = $decodedJson;
+        }
 
         foreach ($json as $key => $value) {
             $classKey = $this->getClassKey($key);


### PR DESCRIPTION
Hi @vlungusst,

I'm currently getting "error code: 1020" from ZeroBounce, but since there is no check in the deserialize method, 
- json_decode returns null
- then a foreach is done on null
- I get an error about the foreach on null

An early exception is more useful to have the correct issue.